### PR TITLE
update component colors in HTML

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -1100,7 +1100,7 @@
           "name": "Property Values for CSS",
           "scope": [
              "support.constant.font-name",
-             "support.constant.color" 
+             "support.constant.color"
           ],
           "settings": {
               "foreground": "{{ orange }}"
@@ -1805,6 +1805,15 @@
           "settings": {
               "foreground": "{{ purple }}",
               "fontStyle": ""
+          }
+      },
+      {
+          "name": "HTML Class Component (Vue, React, etc)",
+          "scope": [
+              "support.class.component.html"
+          ],
+          "settings": {
+              "foreground": "{{ red }}"
           }
       },
       {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electron-highlighter",
   "displayName": "Electron Highlighter Syntax",
   "description": "Electron highlighter syntax theme from Atom",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -10,7 +10,7 @@
   },
   "bugs": {
     "url": "https://github.com/mikemcbride/vscode-electron-highlighter/issues",
-    "email": "mmcbride1007@icloud.com"
+    "email": "mike.mcbride@hey.com"
   },
   "publisher": "mikemcbride",
   "engines": {

--- a/themes/electron-highlighter-color-theme.json
+++ b/themes/electron-highlighter-color-theme.json
@@ -1808,6 +1808,15 @@
             }
         },
         {
+            "name": "HTML Class Component (Vue, React, etc)",
+            "scope": [
+                "support.class.component.html"
+            ],
+            "settings": {
+                "foreground": "#ff5874"
+            }
+        },
+        {
             "name": "Text nested in React tags",
             "scope": [
                 "meta.jsx.children",


### PR DESCRIPTION
It looks like components (Vue, React) started getting new tokens recently and it's causing them to be yellow instead of red. This adjusts some tokens to make it consistent with other HTML elements.